### PR TITLE
Completed requirements specification (PyQt4 and requests) and improved setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 *.coinscript
 *.conf
 Hashmal*.egg-info
+# Built package
+build/
+dist/

--- a/README.md
+++ b/README.md
@@ -23,6 +23,30 @@ Hashmal is intended for cryptocurrency developers and power users.
 - When editing scripts, put something in double quotation marks to ensure it's interpreted as text rather than hex data.
 - You can quickly evaluate the script you're working on via *Script > Evaluate* in the menubar.
 
+## Libraries
+To run the application you must use / have installed:
+ - Python 2.7
+ - PyQt4
+
+### PyQt4
+You can install PyQt4 if you use Anaconda with the following command
+```
+conda install pyqt=4
+```
+If you use Debian / Ubuntu, you can use the following command
+```
+sudo apt install pyqt4-dev-tools
+```
+Installation instructions for other platforms:
+[https://www.riverbankcomputing.com/software/pyqt/download](https://www.riverbankcomputing.com/software/pyqt/download)
+
+### Installation
+After that, use `setup.py` to build / install the application
+```
+python setup.py install
+```
+This will install the external module requirements listed in `requirements.txt` too
+
 ## Documentation
 
 See the file `doc/usage.adoc` for basic instructions. See the [Hashmal wiki on Github](https://github.com/mazaclub/hashmal/wiki) for details.

--- a/hashmal_lib/__init__.py
+++ b/hashmal_lib/__init__.py
@@ -1,16 +1,14 @@
 import sys
 
-from PyQt4.QtGui import QApplication
-
-from main_window import HashmalMain
-
 
 class HashmalGui(object):
     def __init__(self):
+	from PyQt4.QtGui import QApplication
         super(HashmalGui, self).__init__()
         self.app = QApplication(sys.argv)
 
     def main(self):
+	from main_window import HashmalMain
         self.main_window = HashmalMain(self.app)
         self.main_window.show()
         sys.exit(self.app.exec_())

--- a/hashmal_lib/entry_points.py
+++ b/hashmal_lib/entry_points.py
@@ -1,0 +1,16 @@
+hashmal_entry_points = {
+    'hashmal.plugin': [
+        'Address Encoder = hashmal_lib.plugins.addr_encoder:make_plugin',
+        'Block Analyzer = hashmal_lib.plugins.block_analyzer:make_plugin',
+        'Blockchain = hashmal_lib.plugins.blockchain:make_plugin',
+        'Chainparams = hashmal_lib.plugins.chainparams:make_plugin',
+        'Item Types = hashmal_lib.plugins.item_types:make_plugin',
+        'Log = hashmal_lib.plugins.log:make_plugin',
+        'Script Generator = hashmal_lib.plugins.script_gen:make_plugin',
+        'Stack Evaluator = hashmal_lib.plugins.stack:make_plugin',
+        'Transaction Analyzer = hashmal_lib.plugins.tx_analyzer:make_plugin',
+        'Transaction Builder = hashmal_lib.plugins.tx_builder:make_plugin',
+        'Variables = hashmal_lib.plugins.variables:make_plugin',
+        'Wallet RPC = hashmal_lib.plugins.wallet_rpc:make_plugin'
+    ]
+}

--- a/hashmal_lib/gui_utils.py
+++ b/hashmal_lib/gui_utils.py
@@ -243,22 +243,7 @@ class ReadOnlyCheckBox(QtGui.QCheckBox):
     readOnly = QtCore.pyqtProperty(bool, isReadOnly, setReadOnly)
 
 
-hashmal_entry_points = {
-    'hashmal.plugin': [
-        'Address Encoder = hashmal_lib.plugins.addr_encoder:make_plugin',
-        'Block Analyzer = hashmal_lib.plugins.block_analyzer:make_plugin',
-        'Blockchain = hashmal_lib.plugins.blockchain:make_plugin',
-        'Chainparams = hashmal_lib.plugins.chainparams:make_plugin',
-        'Item Types = hashmal_lib.plugins.item_types:make_plugin',
-        'Log = hashmal_lib.plugins.log:make_plugin',
-        'Script Generator = hashmal_lib.plugins.script_gen:make_plugin',
-        'Stack Evaluator = hashmal_lib.plugins.stack:make_plugin',
-        'Transaction Analyzer = hashmal_lib.plugins.tx_analyzer:make_plugin',
-        'Transaction Builder = hashmal_lib.plugins.tx_builder:make_plugin',
-        'Variables = hashmal_lib.plugins.variables:make_plugin',
-        'Wallet RPC = hashmal_lib.plugins.wallet_rpc:make_plugin'
-    ]
-}
+from entry_points import hashmal_entry_points
 
 
 required_plugins = ['Chainparams', 'Item Types', 'Log', 'Stack Evaluator', 'Variables']
@@ -266,4 +251,3 @@ required_plugins = ['Chainparams', 'Item Types', 'Log', 'Stack Evaluator', 'Vari
 
 default_plugins = ['Blockchain', 'Chainparams', 'Item Types', 'Log', 'Script Generator', 'Stack Evaluator',
                     'Transaction Analyzer', 'Transaction Builder', 'Variables', 'Wallet RPC']
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 python-bitcoinlib
 pyparsing
+requests

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from setuptools import setup
-from hashmal_lib.gui_utils import hashmal_entry_points
+from hashmal_lib.entry_points import hashmal_entry_points
 
 with open('requirements.txt') as f:
     requirements = f.readlines()


### PR DESCRIPTION
# Changelist:
- Fixed `setup.py` to work without having `PyQt4` installed (so you can install it later):
  - Created `hashmal_lib.entry_points` module to contain entry points
  - Moved `hashmal_lib.gui_utils` module's constant `hashmal_entry_points` to previously created file
    Contains a reference to it to mantain constant in both modules
  - Changed `setup.py` import `from hashmal_lib.gui_utils import hashmal_entry_points` to `from hashmal_lib.entry_points import hashmal_entry_points`
  - Moved `hashmal_lib.__init__` module imports to inside the class (so doesn't import `PyQt4` until instanced)
- Added `requests` module as a requirement in `requirements.txt`
- Explained in `README.md` the `PyQt4` requirement and a basic how-to to install the module
- Added `build/` and `dist/` to `.gitignore`